### PR TITLE
Fix broken path parsing on windows chromium

### DIFF
--- a/pkgs/froute/package.json
+++ b/pkgs/froute/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fleur/froute",
-  "version": "1.0.7",
+  "version": "1.0.8-dev",
   "description": "Type safe and flexible router for React",
   "repository": {
     "url": "https://github.com/fleur-js/froute"

--- a/pkgs/froute/src/utils.ts
+++ b/pkgs/froute/src/utils.ts
@@ -18,11 +18,11 @@ export const isEmptyObject = (t: object) => {
 };
 
 export const parseUrl = (url: string) => {
-  const result = new URL(url, "p:/___.com");
+  const result = new URL(url, "pl:/___.com");
   const path = result.pathname + result.search;
 
   return {
-    protocol: result.protocol === "p:" ? null : result.protocol,
+    protocol: result.protocol === "pl:" ? null : result.protocol,
     // slashes: null,
     auth:
       result.username !== "" || result.password !== ""
@@ -39,7 +39,7 @@ export const parseUrl = (url: string) => {
         ? null
         : result.pathname,
     path: path === "" || path === "/___.com" ? null : path,
-    href: result.href.replace(/^(p:)?(\/___.com)?/g, ""),
+    href: result.href.replace(/^(pl:)?(\/___.com)?/g, ""),
   };
 };
 


### PR DESCRIPTION
The `p:/___.com` used as the second argument of the URL constructor was interpreted as a drive letter in Chromium-based browsers on Windows, and the URL after interpretation was `file://p:/___.com`.

By using a two-letter protocol name, it is interpreted as a normal protocol and works as intended.